### PR TITLE
Add udpated meta dependency.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/meta"]
 	path = deps/meta
-	url = https://github.com/meta-toolkit/meta.git
+	url = https://github.com/ccasey645/meta.git
 [submodule "deps/pybind11"]
 	path = deps/pybind11
 	url = https://github.com/pybind/pybind11


### PR DESCRIPTION
Add updated ICU dependency URL in Meta submodule since TGZ file download moved to new URL. This allows this repo to be built for Python 3.8 and 3.9.